### PR TITLE
Change namespace to use one in vitrolib

### DIFF
--- a/reference-ontologies/measurement/target-ontologies/measurement.owl
+++ b/reference-ontologies/measurement/target-ontologies/measurement.owl
@@ -2,10 +2,10 @@
 <!-- 
     WARNING:  THIS IS A WORKING DRAFT ONTOLOGY AND STILL UNDER DEVELOPMENT, this file will change frequently and significantly as development continues.
     
-    Note:  http://measurement.example.org/ is a placeholder (fake) namespace for the LD4P/L Measurements ontology extension until a proper home is found
+    Note:  http://measurement.bibliotek-o.org/ is a placeholder (fake) namespace for the LD4P/L Measurements ontology extension until a proper home is found
   -->
 
-<rdf:RDF xmlns="http://measurement.example.org/"
+<rdf:RDF xmlns="http://measurement.bibliotek-o.org/"
     xmlns:bf="http://id.loc.gov/ontologies/bibframe/" 
     xmlns:dcterms="http://purl.org/dc/terms/" 
     xmlns:owl="http://www.w3.org/2002/07/owl#"
@@ -19,7 +19,7 @@
 
     <!-- ONTOLOGY DECLARATION -->
 
-    <owl:Ontology rdf:about="http://measurement.example.org/">
+    <owl:Ontology rdf:about="http://measurement.bibliotek-o.org/">
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Version
             0.0</owl:versionInfo>
         <rdfs:label xml:lang="en">ArtFrame: extension ontology for describing art
@@ -33,7 +33,7 @@
 
     <!-- CLASSES -->
 
-    <owl:Class rdf:about="http://measurement.example.org/MeasurementGroup">
+    <owl:Class rdf:about="http://measurement.bibliotek-o.org/MeasurementGroup">
         <rdfs:label>Measurement Group</rdfs:label>
         <skos:definition xml:lang="en-us">A set of measurements pertaining to a specific resource,
             part of a resource, or resource in a particular arrangement. For example, a book may
@@ -43,7 +43,7 @@
             Measurements attached to it.</skos:definition>
     </owl:Class>
 
-    <owl:Class rdf:about="http://measurement.example.org/Measurement">
+    <owl:Class rdf:about="http://measurement.bibliotek-o.org/Measurement">
         <rdfs:label>Measurement</rdfs:label>
         <skos:definition xml:lang="en-us">The measurement of a single aspect of a resource,
             including value, units, and the dimension measured. For example, a book may have a
@@ -51,7 +51,7 @@
             a MeasurementGroup.</skos:definition>
     </owl:Class>
 
-    <owl:Class rdf:about="http://measurement.example.org/Arrangement">
+    <owl:Class rdf:about="http://measurement.bibliotek-o.org/Arrangement">
         <rdfs:label>Arrangement</rdfs:label>
         <skos:definition xml:lang="en-us">The arrangement, organization, or configuration of a
             single object or collection of objects. For example, a parchment may be rolled or
@@ -61,86 +61,86 @@
 
     <!-- OBJECT PROPERTIES -->
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/hasMeasurementGroup">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/hasMeasurementGroup">
         <rdfs:label xml:lang="en">has measurement group</rdfs:label>
         <skos:definition xml:lang="en">The relationship of a resource to a measurement group,
             indicating that the measurement group applies to the resource.</skos:definition>
-        <rdfs:range rdf:resource="http://measurement.example.org/MeasurementGroup"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/isMeasurementGroupOf"/>
+        <rdfs:range rdf:resource="http://measurement.bibliotek-o.org/MeasurementGroup"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/isMeasurementGroupOf"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/isMeasurementGroupOf">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/isMeasurementGroupOf">
         <rdfs:label xml:lang="en">is measurement group of</rdfs:label>
         <skos:definition xml:lang="en">The relationship of a measurement group to a resource,
             indicating that the measurement group applies to the resource.</skos:definition>
-        <rdfs:domain rdf:resource="http://measurement.example.org/MeasurementGroup"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/hasMeasurementGroup"/>
+        <rdfs:domain rdf:resource="http://measurement.bibliotek-o.org/MeasurementGroup"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/hasMeasurementGroup"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/hasMeasurement">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/hasMeasurement">
         <rdfs:label xml:lang="en">has measurement</rdfs:label>
         <skos:definition xml:lang="en">The relationship of a reasourse to a
             measurement.</skos:definition>
-        <rdfs:range rdf:resource="http://measurement.example.org/Measurement"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/isMeasurementOf"/>
+        <rdfs:range rdf:resource="http://measurement.bibliotek-o.org/Measurement"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/isMeasurementOf"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/isMeasurementOf">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/isMeasurementOf">
         <rdfs:label xml:lang="en">is measurement of</rdfs:label>
         <skos:definition xml:lang="en">The relationship of a measurement to a
             resource.</skos:definition>
-        <rdfs:domain rdf:resource="http://measurement.example.org/Measurement"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/hasMeasurement"/>
+        <rdfs:domain rdf:resource="http://measurement.bibliotek-o.org/Measurement"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/hasMeasurement"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/measures">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/measures">
         <rdfs:label xml:lang="en">measures</rdfs:label>
         <skos:definition xml:lang="en">The relationship between a Measurement and the dimension or
             other aspect of a resource that is measured by this Measurement. For example, a
             Measurement may specify the length, height, weight, file size, etc. of a
             resource.</skos:definition>
-        <rdfs:domain rdf:resource="http://measurement.example.org/Measurement"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/measuredBy"/>
+        <rdfs:domain rdf:resource="http://measurement.bibliotek-o.org/Measurement"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/measuredBy"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/measuredBy">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/measuredBy">
         <rdfs:label xml:lang="en">measured by</rdfs:label>
         <skos:definition xml:lang="en">The relationship between a dimension or other aspect of a
             resource and the Measurement that measures it. For example, the length, height, weight,
             file size, etc. of a resource may be the aspect that is measured by a particular
             Measurement.</skos:definition>
-        <rdfs:range rdf:resource="http://measurement.example.org/Measurement"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/measures"/>
+        <rdfs:range rdf:resource="http://measurement.bibliotek-o.org/Measurement"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/measures"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/hasUnit">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/hasUnit">
         <rdfs:label xml:lang="en">has unit</rdfs:label>
         <skos:definition xml:lang="en">Relationship between the measurement and the unit used to
             express the measurement.</skos:definition>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/isUnitOf"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/isUnitOf"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/isUnitOf">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/isUnitOf">
         <rdfs:label xml:lang="en">is unit of</rdfs:label>
         <skos:definition xml:lang="en">Relationship between the unit and the measurement used to
             express the measurement.</skos:definition>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/hasUnit"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/hasUnit"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/hasArrangement">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/hasArrangement">
         <rdfs:label xml:lang="en">has arrangement</rdfs:label>
         <skos:definition xml:lang="en">Relationship between the resource and a specified
             arrangement, organization, or configuration of it.</skos:definition>
-        <rdfs:range rdf:resource="http://measurement.example.org/Arrangement"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/isArrangementOf"/>
+        <rdfs:range rdf:resource="http://measurement.bibliotek-o.org/Arrangement"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/isArrangementOf"/>
     </owl:ObjectProperty>
 
-    <owl:ObjectProperty rdf:about="http://measurement.example.org/isArrangementOf">
+    <owl:ObjectProperty rdf:about="http://measurement.bibliotek-o.org/isArrangementOf">
         <rdfs:label xml:lang="en">is arrangement of</rdfs:label>
         <skos:definition xml:lang="en">Relationship between a specified arrangement, organization,
             or configuration and a resource.</skos:definition>
-        <rdfs:domain rdf:resource="http://measurement.example.org/Arrangement"/>
-        <owl:inverseOf rdf:resource="http://measurement.example.org/hasArrangement"/>
+        <rdfs:domain rdf:resource="http://measurement.bibliotek-o.org/Arrangement"/>
+        <owl:inverseOf rdf:resource="http://measurement.bibliotek-o.org/hasArrangement"/>
     </owl:ObjectProperty>
 
 </rdf:RDF>


### PR DESCRIPTION
Hi Steven, There's been confusion about the measurement namespace between here and vitrolib. I think I initiated that, so apologies. This pull request switches everything back to measurement.bibliotek-o.org instead of measurement.example.org. At this point it was easier to change it here than in vitrolib.